### PR TITLE
WP_Error during user registration when username already exists

### DIFF
--- a/includes/forms/class-wpum-form-register.php
+++ b/includes/forms/class-wpum-form-register.php
@@ -436,6 +436,7 @@ class WPUM_Form_Register extends WPUM_Form {
 
 			$do_user = self::random_psw_registration( $username, $email );
 			$pwd     = $do_user['pwd'];
+			$do_user = $do_user['do_user'];
 
 		} else {
 
@@ -444,9 +445,7 @@ class WPUM_Form_Register extends WPUM_Form {
 
 		}
 
-		// Check for errors.
-		$do_user = isset( $do_user['do_user'] ) ? $do_user['do_user'] : $do_user;
-
+		// check for errors
 		if ( is_wp_error( $do_user ) ) {
 
 			foreach ($do_user->errors as $error) {


### PR DESCRIPTION
When trying to register with not existing email but with existing username a fatal error is thrown because wp_create_user return WP_Error and not Array.

`Fatal error: Uncaught Error: Cannot use object of type WP_Error as array in /Users/shpetimshala/Sites/schniider/wp-content/plugins/wp-user-manager/includes/forms/class-wpum-form-register.php:448 Stack trace: #0 /Users/shpetimshala/Sites/schniider/wp-content/plugins/wp-user-manager/includes/forms/class-wpum-form-register.php(421): WPUM_Form_Register::do_registration('shpetimshala', 'shpetim.shala@t...', Array) #1 /Users/shpetimshala/Sites/schniider/wp-includes/class-wp-hook.php(298): WPUM_Form_Register::process(Object(WP)) #2 /Users/shpetimshala/Sites/schniider/wp-includes/class-wp-hook.php(323): WP_Hook->apply_filters(NULL, Array) #3 /Users/shpetimshala/Sites/schniider/wp-includes/plugin.php(515): WP_Hook->do_action(Array) #4 /Users/shpetimshala/Sites/schniider/wp-includes/class-wp.php(746): do_action_ref_array('wp', Array) #5 /Users/shpetimshala/Sites/schniider/wp-includes/functions.php(955): WP->main('') #6 /Users/shpetimshala/Sites/schniider/wp-blog-header.php(16): wp() #7 /Users/shpetimshala/Sites/schniider/index.php( in /Users/shpetimshala/Sites/schniider/wp-content/plugins/wp-user-manager/includes/forms/class-wpum-form-register.php on line 448`