### PR TITLE
fix $do_user error because WP_Error is object

### DIFF
--- a/includes/forms/class-wpum-form-register.php
+++ b/includes/forms/class-wpum-form-register.php
@@ -445,8 +445,12 @@ class WPUM_Form_Register extends WPUM_Form {
 		}
 
 		// Check for errors.
-		$do_user = isset( $do_user['do_user'] ) ? $do_user['do_user'] : $do_user;
-
+		if (is_object($do_user)) {
+			    $do_user = isset( $do_user->do_user ) ? $do_user->do_user : $do_user;
+		} elseif (is_array($do_user)) {
+			    $do_user = isset( $do_user['do_user'] ) ? $do_user['do_user'] : $do_user;
+		}
+		
 		if ( is_wp_error( $do_user ) ) {
 
 			foreach ($do_user->errors as $error) {


### PR DESCRIPTION
at /register page, when username is not valid(acquired by other users), a fatal PHP error occurred :
Cannot use object of type WP_Error as array 
I fix that, with use $do_user as object